### PR TITLE
Modify upload image url

### DIFF
--- a/simditor/views.py
+++ b/simditor/views.py
@@ -66,6 +66,8 @@ class ImageUploadView(generic.View):
 
         saved_path = self._save_file(request, uploaded_file)
         url = utils.get_media_url(saved_path)
+        is_api = settings.SIMDITOR_CONFIGS.get('is_api', False)
+        url = request.META.get('HTTP_ORIGIN') + url if is_api else url
 
         retdata = {'file_path': url, 'success': True,
                    'msg': '上传成功!'}

--- a/simditor_demo/simditor_demo/settings.py
+++ b/simditor_demo/simditor_demo/settings.py
@@ -147,5 +147,6 @@ SIMDITOR_CONFIGS = {
     },
     'emoji': {
         'imagePath': '/static/simditor/images/emoji/'
-    }
+    },
+    'is_api': False
 }


### PR DESCRIPTION
在`setting`设置`is_api` 为`True`时，上传图片的地址将当前请求头里的`ORIGIN`与`media url` 作为新的图片地址